### PR TITLE
Improve geo selection UX with caching and reset

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+DATABASE_URL=postgresql+psycopg2://postgres:YOUR_PASSWORD@127.0.0.1:5432/forwarderett
+CORS_ORIGIN=http://localhost:5173
+SLA_HOURS=2

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,6 @@
+.env
+venv/
+__pycache__/
+*.pyc
+*.pyo
+*.log

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,11 @@
+- venv را بساز و requirements نصب کن
+- فایل .env را از روی .env.example بساز و پسورد و SLA_HOURS را تنظیم کن
+- اجرای لوکال:
+  flask --app backend.app run
+- تست:
+  curl "http://127.0.0.1:5000/api/geo/provinces?q=تهران&limit=20"
+
+نکات:
+- همهٔ پاسخ‌های خطا با ساختار JSON شامل فیلدهای `error` و `request_id` برمی‌گردند و در صورت نیاز جزئیات در `details` قرار می‌گیرد.
+- در تمام پاسخ‌ها هدر `X-Request-ID` ست می‌شود.
+- در ثبت درخواست حمل، طول `note_text` حداکثر ۱۴۰ کاراکتر است و قالب‌های ساده برای `contact_phone` و `contact_email` اعتبارسنجی می‌شوند.

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,5 @@
+"""Backend package for geo API."""
+
+from .app import app, create_app
+
+__all__ = ["app", "create_app"]

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,33 @@
+import logging
+
+from flask import Flask
+from flask_cors import CORS
+
+from .config import Config
+from .db import db
+from .geo_routes import geo_bp
+from .request_routes import req_bp
+from .utils.errors import register_error_handlers
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config.from_object(Config)
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    db.init_app(app)
+    CORS(app, resources={r"/api/*": {"origins": [app.config["CORS_ORIGIN"]]}})
+    app.register_blueprint(geo_bp, url_prefix="/api")
+    app.register_blueprint(req_bp, url_prefix="/api")
+    register_error_handlers(app)
+
+    @app.get("/api/health")
+    def health():
+        return {"ok": True}
+
+    return app
+
+
+app = create_app()

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,14 @@
+from os import getenv
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+SLA_HOURS = int(getenv("SLA_HOURS", "2"))
+
+
+class Config:
+    SQLALCHEMY_DATABASE_URI = getenv("DATABASE_URL")
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    SQLALCHEMY_ENGINE_OPTIONS = {"pool_pre_ping": True}
+    CORS_ORIGIN = getenv("CORS_ORIGIN", "http://localhost:5173")

--- a/backend/db.py
+++ b/backend/db.py
@@ -1,0 +1,3 @@
+from flask_sqlalchemy import SQLAlchemy
+
+db = SQLAlchemy()

--- a/backend/geo_models.py
+++ b/backend/geo_models.py
@@ -1,0 +1,31 @@
+from .db import db
+
+
+class Province(db.Model):
+    __tablename__ = "province"
+    id = db.Column(db.BigInteger, primary_key=True)
+    name_fa = db.Column(db.Text, nullable=False)
+
+
+class County(db.Model):
+    __tablename__ = "county"
+    id = db.Column(db.BigInteger, primary_key=True)
+    province_id = db.Column(
+        db.BigInteger,
+        db.ForeignKey("province.id"),
+        index=True,
+        nullable=False,
+    )
+    name_fa = db.Column(db.Text, nullable=False)
+
+
+class City(db.Model):
+    __tablename__ = "city"
+    id = db.Column(db.BigInteger, primary_key=True)
+    county_id = db.Column(
+        db.BigInteger,
+        db.ForeignKey("county.id"),
+        index=True,
+        nullable=False,
+    )
+    name_fa = db.Column(db.Text, nullable=False)

--- a/backend/geo_routes.py
+++ b/backend/geo_routes.py
@@ -1,0 +1,68 @@
+from flask import Blueprint, jsonify, request
+from sqlalchemy import select
+
+from .db import db
+from .geo_models import City, County, Province
+
+geo_bp = Blueprint("geo", __name__)
+
+
+def _qpl():
+    q = (request.args.get("q") or "").strip()
+    try:
+        page = max(1, int(request.args.get("page", 1)))
+        limit = min(1000, max(1, int(request.args.get("limit", 50))))
+    except ValueError:
+        page, limit = 1, 50
+    return q, page, limit
+
+
+@geo_bp.get("/geo/provinces")
+def provinces():
+    q, page, limit = _qpl()
+    stmt = select(Province.id, Province.name_fa)
+    if q:
+        stmt = stmt.where(Province.name_fa.ilike(f"%{q}%"))
+    stmt = stmt.order_by(Province.name_fa).limit(limit).offset((page - 1) * limit)
+    rows = db.session.execute(stmt).all()
+    return jsonify([{"id": r.id, "name_fa": r.name_fa} for r in rows])
+
+
+@geo_bp.get("/geo/counties")
+def counties():
+    q, page, limit = _qpl()
+    pid = request.args.get("province_id", type=int)
+    if not pid:
+        return jsonify({"error": "province_id الزامی است"}), 400
+    stmt = select(County.id, County.province_id, County.name_fa).where(
+        County.province_id == pid
+    )
+    if q:
+        stmt = stmt.where(County.name_fa.ilike(f"%{q}%"))
+    stmt = stmt.order_by(County.name_fa).limit(limit).offset((page - 1) * limit)
+    rows = db.session.execute(stmt).all()
+    return jsonify(
+        [
+            {"id": r.id, "province_id": r.province_id, "name_fa": r.name_fa}
+            for r in rows
+        ]
+    )
+
+
+@geo_bp.get("/geo/cities")
+def cities():
+    q, page, limit = _qpl()
+    cid = request.args.get("county_id", type=int)
+    if not cid:
+        return jsonify({"error": "county_id الزامی است"}), 400
+    stmt = select(City.id, City.county_id, City.name_fa).where(City.county_id == cid)
+    if q:
+        stmt = stmt.where(City.name_fa.ilike(f"%{q}%"))
+    stmt = stmt.order_by(City.name_fa).limit(limit).offset((page - 1) * limit)
+    rows = db.session.execute(stmt).all()
+    return jsonify(
+        [
+            {"id": r.id, "county_id": r.county_id, "name_fa": r.name_fa}
+            for r in rows
+        ]
+    )

--- a/backend/request_routes.py
+++ b/backend/request_routes.py
@@ -1,0 +1,87 @@
+from flask import Blueprint, jsonify, request
+
+from .db import db
+from .geo_models import City, County, Province
+from .shipment_models import ShipmentRequest
+from .utils.errors import json_error
+from .utils.validators import valid_email, valid_note, valid_phone
+
+req_bp = Blueprint("req", __name__)
+
+
+def _exists(model, id_):
+    return (
+        db.session.query(model.id).filter(model.id == id_).first() is not None
+    )
+
+
+@req_bp.post("/requests")
+def create_request():
+    data = request.get_json(force=True, silent=True) or {}
+    required = [
+        "origin_province_id",
+        "origin_county_id",
+        "origin_city_id",
+        "dest_province_id",
+        "dest_county_id",
+        "dest_city_id",
+    ]
+    missing = [key for key in required if not data.get(key)]
+    if missing:
+        return json_error(400, "فیلدهای اجباری ناقص است.", {"missing": missing})
+
+    if not _exists(Province, data["origin_province_id"]):
+        return json_error(400, "استان مبدأ نامعتبر است.")
+    if not _exists(County, data["origin_county_id"]):
+        return json_error(400, "شهرستان مبدأ نامعتبر است.")
+    if not _exists(City, data["origin_city_id"]):
+        return json_error(400, "شهر مبدأ نامعتبر است.")
+    if not _exists(Province, data["dest_province_id"]):
+        return json_error(400, "استان مقصد نامعتبر است.")
+    if not _exists(County, data["dest_county_id"]):
+        return json_error(400, "شهرستان مقصد نامعتبر است.")
+    if not _exists(City, data["dest_city_id"]):
+        return json_error(400, "شهر مقصد نامعتبر است.")
+
+    note = data.get("note_text")
+    phone = data.get("contact_phone")
+    email = data.get("contact_email")
+
+    if not valid_note(note):
+        return json_error(400, "طول یادداشت نباید بیش از ۱۴۰ کاراکتر باشد.")
+
+    if phone and not valid_phone(phone):
+        return json_error(
+            400,
+            "قالب شماره تلفن نامعتبر است. فقط ارقام، فاصله، +، -، پرانتز مجاز است.",
+        )
+
+    if email and not valid_email(email):
+        return json_error(400, "قالب ایمیل نامعتبر است.")
+
+    req = ShipmentRequest(
+        origin_province_id=data["origin_province_id"],
+        origin_county_id=data["origin_county_id"],
+        origin_city_id=data["origin_city_id"],
+        dest_province_id=data["dest_province_id"],
+        dest_county_id=data["dest_county_id"],
+        dest_city_id=data["dest_city_id"],
+        contact_name=data.get("contact_name"),
+        contact_phone=phone or None,
+        contact_email=email or None,
+        note_text=note or None,
+        status_request_status="NEW",
+    )
+    req.set_sla_due()
+    db.session.add(req)
+    db.session.commit()
+    return (
+        jsonify(
+            {
+                "id": req.id,
+                "status": req.status_request_status,
+                "sla_due_at": req.sla_due_at.isoformat() if req.sla_due_at else None,
+            }
+        ),
+        201,
+    )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+Flask==3.1.2
+Flask-SQLAlchemy==3.1.1
+Flask-Cors==4.0.1
+psycopg2-binary==2.9.9
+python-dotenv==1.0.1

--- a/backend/shipment_models.py
+++ b/backend/shipment_models.py
@@ -1,0 +1,44 @@
+from datetime import datetime, timedelta
+
+from .db import db
+from .config import SLA_HOURS
+
+
+class ShipmentRequest(db.Model):
+    __tablename__ = "shipment_request"
+
+    id = db.Column(db.BigInteger, primary_key=True)
+    shipper_id = db.Column(db.BigInteger)
+    origin_province_id = db.Column(db.BigInteger, nullable=False)
+    origin_county_id = db.Column(db.BigInteger, nullable=False)
+    origin_city_id = db.Column(db.BigInteger, nullable=False)
+    dest_province_id = db.Column(db.BigInteger, nullable=False)
+    dest_county_id = db.Column(db.BigInteger, nullable=False)
+    dest_city_id = db.Column(db.BigInteger, nullable=False)
+
+    ready_at = db.Column(db.DateTime(timezone=True))
+    mode_shipment_mode = db.Column(db.Text)
+    incoterm_code = db.Column(db.Text)
+    is_hazardous = db.Column(db.Boolean)
+    is_refrigerated = db.Column(db.Boolean)
+    commodity_name = db.Column(db.Text)
+    hs_code = db.Column(db.Text)
+    package_type = db.Column(db.Text)
+    units = db.Column(db.Integer)
+    length_cm = db.Column(db.Numeric(10, 2))
+    width_cm = db.Column(db.Numeric(10, 2))
+    height_cm = db.Column(db.Numeric(10, 2))
+    weight_kg = db.Column(db.Numeric(10, 2))
+    volume_m3 = db.Column(db.Numeric(10, 2))
+    contact_name = db.Column(db.Text)
+    contact_phone = db.Column(db.Text)
+    contact_email = db.Column(db.Text)
+    note_text = db.Column(db.Text)
+
+    status_request_status = db.Column(db.Text, default="NEW", nullable=False)
+    created_at = db.Column(db.DateTime(timezone=True), default=db.func.now(), nullable=False)
+    sla_due_at = db.Column(db.DateTime(timezone=True))
+    requester_user_id = db.Column(db.BigInteger)
+
+    def set_sla_due(self) -> None:
+        self.sla_due_at = datetime.utcnow() + timedelta(hours=SLA_HOURS)

--- a/backend/utils/__init__.py
+++ b/backend/utils/__init__.py
@@ -1,0 +1,3 @@
+"""Utility helpers for backend services."""
+
+__all__ = ["validators", "errors"]

--- a/backend/utils/errors.py
+++ b/backend/utils/errors.py
@@ -1,0 +1,65 @@
+import logging
+import traceback
+import uuid
+from flask import g, jsonify, request
+
+log = logging.getLogger(__name__)
+
+
+def ensure_request_id() -> str:
+    request_id = request.headers.get("X-Request-ID") or str(uuid.uuid4())
+    g.request_id = request_id
+    return request_id
+
+
+def add_request_id_header(response):
+    request_id = getattr(g, "request_id", None)
+    if request_id:
+        response.headers["X-Request-ID"] = request_id
+    return response
+
+
+def json_error(status: int, message_fa: str, details: dict | None = None):
+    payload: dict[str, object | None] = {
+        "error": message_fa,
+        "request_id": getattr(g, "request_id", None),
+    }
+    if details:
+        payload["details"] = details
+    return jsonify(payload), status
+
+
+def register_error_handlers(app):
+    @app.before_request
+    def _assign_rid():
+        ensure_request_id()
+
+    @app.after_request
+    def _attach_rid(response):
+        return add_request_id_header(response)
+
+    @app.errorhandler(400)
+    def _bad_request(error):
+        return json_error(400, "درخواست نامعتبر است.", {"type": "BadRequest"})
+
+    @app.errorhandler(404)
+    def _not_found(error):
+        return json_error(404, "یافت نشد.", {"type": "NotFound"})
+
+    @app.errorhandler(405)
+    def _method_not_allowed(error):
+        return json_error(405, "روش مجاز نیست.", {"type": "MethodNotAllowed"})
+
+    @app.errorhandler(500)
+    def _server_error(error):
+        request_id = getattr(g, "request_id", "-")
+        log.exception(
+            "Unhandled 500 (request_id=%s): %s", request_id, traceback.format_exc()
+        )
+        return json_error(
+            500,
+            "خطای داخلی سرور رخ داد.",
+            {"type": "InternalServerError"},
+        )
+
+    return app

--- a/backend/utils/validators.py
+++ b/backend/utils/validators.py
@@ -1,0 +1,22 @@
+import re
+
+PHONE_RE = re.compile(r"^[0-9+\-\s()]{6,20}$")
+EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+def valid_phone(value: str | None) -> bool:
+    if not value:
+        return True
+    return bool(PHONE_RE.match(value.strip()))
+
+
+def valid_email(value: str | None) -> bool:
+    if not value:
+        return True
+    return bool(EMAIL_RE.match(value.strip()))
+
+
+def valid_note(value: str | None) -> bool:
+    if value is None:
+        return True
+    return len(value) <= 140

--- a/src/components/CascadingSelect.tsx
+++ b/src/components/CascadingSelect.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useMemo, useState } from "react";
+import { geoApi } from "@/lib/api";
+import { debounce } from "./Debounce";
+
+type Sel = { id: number; name_fa: string };
+
+export type GeoValue = {
+  province_id?: number;
+  county_id?: number;
+  city_id?: number;
+};
+
+export function CascadingSelect({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: GeoValue;
+  onChange: (v: GeoValue) => void;
+}) {
+  const [provQ, setProvQ] = useState("");
+  const [provList, setProvList] = useState<Sel[]>([]);
+  const [countyQ, setCountyQ] = useState("");
+  const [countyList, setCountyList] = useState<Sel[]>([]);
+  const [cityQ, setCityQ] = useState("");
+  const [cityList, setCityList] = useState<Sel[]>([]);
+
+  const fetchProv = useMemo(
+    () =>
+      debounce(async (q: string) => {
+        const rows = await geoApi.provinces(q);
+        setProvList(rows);
+      }, 300),
+    []
+  );
+
+  const fetchCounty = useMemo(
+    () =>
+      debounce(async (pid: number, q: string) => {
+        if (!pid) return setCountyList([]);
+        const rows = await geoApi.counties(pid, q);
+        setCountyList(rows);
+      }, 300),
+    []
+  );
+
+  const fetchCity = useMemo(
+    () =>
+      debounce(async (cid: number, q: string) => {
+        if (!cid) return setCityList([]);
+        const rows = await geoApi.cities(cid, q);
+        setCityList(rows);
+      }, 300),
+    []
+  );
+
+  // initial load of provinces
+  useEffect(() => {
+    fetchProv("");
+  }, [fetchProv]);
+
+  // when province changes, reset county/city
+  function setProvince(id?: number) {
+    onChange({ province_id: id, county_id: undefined, city_id: undefined });
+    setCountyList([]);
+    setCityList([]);
+    if (id) fetchCounty(id, "");
+  }
+  function setCounty(id?: number) {
+    const pid = value.province_id!;
+    onChange({ province_id: pid, county_id: id, city_id: undefined });
+    setCityList([]);
+    if (id) fetchCity(id, "");
+  }
+  function setCity(id?: number) {
+    onChange({ ...value, city_id: id });
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="text-sm font-medium">{label}</div>
+
+      {/* Province */}
+      <div className="space-y-1">
+        <input
+          placeholder="جست‌وجوی استان…"
+          className="w-full"
+          onChange={(e) => {
+            setProvQ(e.target.value);
+            fetchProv(e.target.value);
+          }}
+          value={provQ}
+        />
+        <select
+          className="w-full"
+          value={value.province_id ?? ""}
+          onChange={(e) => setProvince(e.target.value ? Number(e.target.value) : undefined)}
+        >
+          <option value="">انتخاب استان</option>
+          {provList.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name_fa}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* County */}
+      <div className="space-y-1">
+        <input
+          placeholder="جست‌وجوی شهرستان…"
+          className="w-full"
+          disabled={!value.province_id}
+          onChange={(e) => {
+            setCountyQ(e.target.value);
+            if (value.province_id) fetchCounty(value.province_id, e.target.value);
+          }}
+          value={countyQ}
+        />
+        <select
+          className="w-full"
+          disabled={!value.province_id}
+          value={value.county_id ?? ""}
+          onChange={(e) => setCounty(e.target.value ? Number(e.target.value) : undefined)}
+        >
+          <option value="">{value.province_id ? "انتخاب شهرستان" : "ابتدا استان را انتخاب کنید"}</option>
+          {countyList.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name_fa}
+            </option>
+          ))}
+        </select>
+        {!value.province_id && (
+          <div className="text-xs mt-1 text-destructive">ابتدا استان را انتخاب کنید.</div>
+        )}
+      </div>
+
+      {/* City */}
+      <div className="space-y-1">
+        <input
+          placeholder="جست‌وجوی شهر…"
+          className="w-full"
+          disabled={!value.county_id}
+          onChange={(e) => {
+            setCityQ(e.target.value);
+            if (value.county_id) fetchCity(value.county_id, e.target.value);
+          }}
+          value={cityQ}
+        />
+        <select
+          className="w-full"
+          disabled={!value.county_id}
+          value={value.city_id ?? ""}
+          onChange={(e) => setCity(e.target.value ? Number(e.target.value) : undefined)}
+        >
+          <option value="">{value.county_id ? "انتخاب شهر" : "ابتدا شهرستان را انتخاب کنید"}</option>
+          {cityList.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name_fa}
+            </option>
+          ))}
+        </select>
+        {!value.county_id && (
+          <div className="text-xs mt-1 text-destructive">ابتدا شهرستان را انتخاب کنید.</div>
+        )}
+      </div>
+
+      {/* breadcrumb */}
+      <div className="text-xs text-muted-foreground">استان › شهرستان › شهر</div>
+    </div>
+  );
+}

--- a/src/components/Debounce.ts
+++ b/src/components/Debounce.ts
@@ -1,0 +1,9 @@
+export function debounce<F extends (...args: unknown[]) => void>(fn: F, wait = 300) {
+  let t: number | undefined;
+  return (...args: Parameters<F>) => {
+    if (t !== undefined) {
+      window.clearTimeout(t);
+    }
+    t = window.setTimeout(() => fn(...args), wait);
+  };
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,86 @@
+import { getCache, setCache, makeGeoKey } from "@/lib/cache";
+
+export const API_BASE = import.meta.env.VITE_API_BASE || "/api";
+
+async function getJSON<T>(url: string): Promise<T> {
+  const r = await fetch(url, { credentials: "omit" });
+  if (!r.ok) throw new Error(`HTTP ${r.status}`);
+  return r.json() as Promise<T>;
+}
+
+type ProvinceRow = { id: number; name_fa: string };
+type CountyRow = { id: number; province_id: number; name_fa: string };
+type CityRow = { id: number; county_id: number; name_fa: string };
+
+export const geoApi = {
+  provinces: async (q = "", page = 1, limit = 50) => {
+    const key = makeGeoKey("provinces", { q, page, limit });
+    const cachedLocal = !q ? getCache<ProvinceRow[]>(key, "local") : null;
+    if (cachedLocal) return cachedLocal;
+
+    const cached = getCache<ProvinceRow[]>(key, "session");
+    if (cached) return cached;
+
+    const url = `${API_BASE}/geo/provinces?q=${encodeURIComponent(q)}&page=${page}&limit=${limit}`;
+    const rows = await getJSON<ProvinceRow[]>(url);
+
+    if (!q) {
+      setCache(key, rows, 24 * 60 * 60 * 1000, "local");
+    }
+    setCache(key, rows, 15 * 60 * 1000, "session");
+    return rows;
+  },
+
+  counties: async (province_id: number, q = "", page = 1, limit = 50) => {
+    const key = makeGeoKey("counties", { province_id, q, page, limit });
+    const cached = getCache<CountyRow[]>(key, "session");
+    if (cached) return cached;
+
+    const url = `${API_BASE}/geo/counties?province_id=${province_id}&q=${encodeURIComponent(q)}&page=${page}&limit=${limit}`;
+    const rows = await getJSON<CountyRow[]>(url);
+    setCache(key, rows, 15 * 60 * 1000, "session");
+    return rows;
+  },
+
+  cities: async (county_id: number, q = "", page = 1, limit = 50) => {
+    const key = makeGeoKey("cities", { county_id, q, page, limit });
+    const cached = getCache<CityRow[]>(key, "session");
+    if (cached) return cached;
+
+    const url = `${API_BASE}/geo/cities?county_id=${county_id}&q=${encodeURIComponent(q)}&page=${page}&limit=${limit}`;
+    const rows = await getJSON<CityRow[]>(url);
+    setCache(key, rows, 15 * 60 * 1000, "session");
+    return rows;
+  },
+};
+
+export type CreateRequestPayload = {
+  origin_province_id: number;
+  origin_county_id: number;
+  origin_city_id: number;
+  dest_province_id: number;
+  dest_county_id: number;
+  dest_city_id: number;
+  contact_name?: string;
+  contact_phone?: string;
+  contact_email?: string;
+  note_text?: string;
+};
+
+export type ShipmentRequestResponse = {
+  id: number;
+  status: string;
+  sla_due_at: string;
+};
+
+export const requestApi = {
+  create: (payload: CreateRequestPayload) =>
+    fetch(`${API_BASE}/requests`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    }).then(async (r) => {
+      if (!r.ok) throw new Error(await r.text());
+      return r.json() as Promise<ShipmentRequestResponse>;
+    }),
+};

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,0 +1,53 @@
+export type CacheLayer = "session" | "local";
+
+const DEFAULT_TTL_MS = 15 * 60 * 1000; // 15 دقیقه
+
+function now() {
+  return Date.now();
+}
+
+function getStorage(layer: CacheLayer) {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  return layer === "local" ? window.localStorage : window.sessionStorage;
+}
+
+export function getCache<T = unknown>(key: string, layer: CacheLayer = "session") {
+  const storage = getStorage(layer);
+  if (!storage) return null;
+  const raw = storage.getItem(key);
+  if (!raw) return null;
+  try {
+    const { t, v, ttl } = JSON.parse(raw);
+    if (ttl && now() - t > ttl) {
+      storage.removeItem(key);
+      return null;
+    }
+    return v as T;
+  } catch {
+    storage.removeItem(key);
+    return null;
+  }
+}
+
+export function setCache<T>(
+  key: string,
+  value: T,
+  ttlMs: number = DEFAULT_TTL_MS,
+  layer: CacheLayer = "session"
+) {
+  const storage = getStorage(layer);
+  if (!storage) return;
+  const payload = JSON.stringify({ t: now(), v: value, ttl: ttlMs });
+  storage.setItem(key, payload);
+}
+
+export function makeGeoKey(endpoint: string, params: Record<string, unknown>) {
+  const qp = Object.entries(params)
+    .filter(([, v]) => v !== undefined && v !== null && v !== "")
+    .map(([k, v]) => `${k}=${encodeURIComponent(String(v))}`)
+    .sort()
+    .join("&");
+  return `geo::${endpoint}${qp ? "::" + qp : ""}`;
+}

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,16 +1,78 @@
 import { useState } from "react";
 import Layout from "@/components/Layout";
 import ProcessStepper from "@/components/ProcessStepper";
-import LocationSelector from "@/components/LocationSelector";
-import ShipmentRequestForm from "@/components/ShipmentRequestForm";
 import { Card, CardContent } from "@/components/ui/card";
+import { CascadingSelect, GeoValue } from "@/components/CascadingSelect";
+import { requestApi, type ShipmentRequestResponse } from "@/lib/api";
 
 const LandingPage = () => {
-  const [originData, setOriginData] = useState<any>({});
-  const [destinationData, setDestinationData] = useState<any>({});
+  const [originData, setOriginData] = useState<GeoValue>({});
+  const [destinationData, setDestinationData] = useState<GeoValue>({});
+  const [contact, setContact] = useState({
+    name: "",
+    phone: "",
+    email: "",
+    note: "",
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<ShipmentRequestResponse | null>(null);
 
-  const isOriginComplete = originData.city_id && originData.county_id && originData.province_id;
-  const isDestinationComplete = destinationData.city_id && destinationData.county_id && destinationData.province_id;
+  const isOriginComplete = Boolean(
+    originData.city_id && originData.county_id && originData.province_id
+  );
+  const isDestinationComplete = Boolean(
+    destinationData.city_id && destinationData.county_id && destinationData.province_id
+  );
+  const ready = isOriginComplete && isDestinationComplete;
+
+  const handleOriginChange = (value: GeoValue) => {
+    setResult(null);
+    setOriginData(value);
+  };
+
+  const handleDestinationChange = (value: GeoValue) => {
+    setResult(null);
+    setDestinationData(value);
+  };
+
+  const updateContact = (field: "name" | "phone" | "email" | "note", value: string) => {
+    setResult(null);
+    setContact((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const resetAll = () => {
+    setOriginData({});
+    setDestinationData({});
+    setResult(null);
+    setContact({ name: "", phone: "", email: "", note: "" });
+  };
+
+  const submitRequest = async () => {
+    if (!ready || submitting) return;
+    setResult(null);
+    setSubmitting(true);
+    try {
+      const payload = {
+        origin_province_id: originData.province_id,
+        origin_county_id: originData.county_id,
+        origin_city_id: originData.city_id,
+        dest_province_id: destinationData.province_id,
+        dest_county_id: destinationData.county_id,
+        dest_city_id: destinationData.city_id,
+        contact_name: contact.name || undefined,
+        contact_phone: contact.phone || undefined,
+        contact_email: contact.email || undefined,
+        note_text: contact.note || undefined,
+      };
+      const response = await requestApi.create(payload);
+      setResult(response);
+    } catch (error) {
+      alert("خطا در ثبت درخواست");
+      console.error(error);
+    } finally {
+      setSubmitting(false);
+    }
+  };
 
   return (
     <Layout>
@@ -31,32 +93,101 @@ const LandingPage = () => {
         {/* Location Selectors */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
           <Card className="shadow-card">
-            <CardContent className="p-6">
-              <LocationSelector
-                type="origin"
-                onLocationChange={setOriginData}
+            <CardContent className="p-6 space-y-4">
+              <CascadingSelect
+                label="مبدأ"
+                value={originData}
+                onChange={handleOriginChange}
               />
             </CardContent>
           </Card>
 
           <Card className="shadow-card">
-            <CardContent className="p-6">
-              <LocationSelector
-                type="destination"
-                onLocationChange={setDestinationData}
+            <CardContent className="p-6 space-y-4">
+              <CascadingSelect
+                label="مقصد"
+                value={destinationData}
+                onChange={handleDestinationChange}
               />
             </CardContent>
           </Card>
         </div>
 
-        {/* Shipment Request Form */}
-        <div className="flex justify-center">
-          <ShipmentRequestForm
-            originComplete={isOriginComplete}
-            destinationComplete={isDestinationComplete}
-            originData={originData}
-            destinationData={destinationData}
-          />
+        <div className="max-w-2xl mx-auto mb-8 space-y-4">
+          {!ready && (
+            <div className="rounded-md p-3 text-sm bg-muted/40">
+              لطفاً ابتدا مبدأ و مقصد را انتخاب کنید.
+            </div>
+          )}
+
+          <button
+            type="button"
+            onClick={resetAll}
+            className="text-xs underline"
+          >
+            ریست مبدأ/مقصد
+          </button>
+
+          {ready && (
+            <pre className="bg-muted/30 p-3 rounded-md text-xs overflow-auto">
+              {JSON.stringify(
+                {
+                  origin_province_id: originData.province_id,
+                  origin_county_id: originData.county_id,
+                  origin_city_id: originData.city_id,
+                  dest_province_id: destinationData.province_id,
+                  dest_county_id: destinationData.county_id,
+                  dest_city_id: destinationData.city_id,
+                },
+                null,
+                2
+              )}
+            </pre>
+          )}
+
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
+            <input
+              placeholder="نام تماس"
+              value={contact.name}
+              onChange={(e) => updateContact("name", e.target.value)}
+              className="w-full"
+            />
+            <input
+              placeholder="تلفن"
+              value={contact.phone}
+              onChange={(e) => updateContact("phone", e.target.value)}
+              type="tel"
+              className="w-full"
+            />
+            <input
+              placeholder="ایمیل"
+              value={contact.email}
+              onChange={(e) => updateContact("email", e.target.value)}
+              type="email"
+              className="w-full"
+            />
+            <input
+              placeholder="یادداشت کوتاه"
+              value={contact.note}
+              onChange={(e) => updateContact("note", e.target.value)}
+              className="w-full"
+            />
+          </div>
+
+          <button
+            type="button"
+            disabled={!ready || submitting}
+            onClick={submitRequest}
+            className="mt-2 inline-flex items-center justify-center rounded-md border px-4 py-2 text-sm font-medium disabled:opacity-60"
+          >
+            {submitting ? "در حال ارسال…" : "ارسال درخواست"}
+          </button>
+
+          {result && (
+            <div className="mt-3 p-3 rounded-md bg-muted/30 text-sm">
+              درخواست شما با شماره <b>{result.id}</b> ثبت شد. تا ۲ ساعت آینده کارشناس بازرگانی با شما تماس خواهد گرفت.
+            </div>
+          )}
         </div>
       </div>
     </Layout>


### PR DESCRIPTION
## Summary
- cache geo lookup responses in sessionStorage with a longer-lived localStorage layer for provinces
- surface inline Persian guidance when dependent selects are disabled and add a reset button plus success messaging polish

## Testing
- npm run lint *(fails due to pre-existing lint errors in shared UI components and tailwind config)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c0ceabe4832880c6011efe2a8d2a